### PR TITLE
ci: remove get-release-version step of publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -77,16 +77,3 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:
           SKIP_PREPACK: true
-
-  get-release-version:
-    runs-on: ubuntu-latest
-    needs: publish-npm
-    outputs:
-      RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
-      - id: get-release-version
-        shell: bash
-        run: ./scripts/get.sh ".version" "RELEASE_VERSION"


### PR DESCRIPTION
This part was inadvertently copied over from another repo and not relevant here.

Needed to unblock releasing.