### PR TITLE
Don't publish extraneous files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "bin": {
     "generate-attribution": "index.js"
   },
+  "files": [
+    "index.js"
+  ],
   "engines": {
     "node": ">=14.0.0"
   },


### PR DESCRIPTION
This limits the files included in the published package.

#### Blocking
- #11 

#### Before
```
$ npm publish --dry-run
npm notice 📦 @metamask/oss-attribution-generator@1.7.1
npm notice === Tarball Contents ===
npm notice 44B .editorconfig
npm notice 3.1kB .gitattributes
npm notice 155B .github/CODEOWNERS
npm notice 1.5kB .github/workflows/create-release-pr.yml
npm notice 2.3kB .github/workflows/main.yml
npm notice 2.4kB .github/workflows/publish-release.yml
npm notice 965B .github/workflows/test.yml
npm notice 15B .mocharc.yaml
npm notice 4B .nvmrc
npm notice 599B .vscode/launch.json
npm notice 1.1kB LICENSE
npm notice 2.7kB README.md
npm notice 8.7kB index.js
npm notice 1.1kB package.json
npm notice 1.7kB test/end-to-end.js
npm notice 735.2kB test/fixture/package-lock.json
npm notice 485B test/fixture/package.json
npm notice === Tarball Details ===
npm notice name: @metamask/oss-attribution-generator
npm notice version: 1.7.1
npm notice filename: @metamask/oss-attribution-generator-1.7.1.tgz
npm notice package size: 189.5 kB
npm notice unpacked size: 762.0 kB
npm notice shasum: 6ee71635589f67020ddeda285f048dbf7cea7db5
npm notice integrity: sha512-I3ibXKU+ly058[...]H7uaGPi24FTHA==
npm notice total files: 17
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ @metamask/oss-attribution-generator@1.7.1
```

#### After
```
$ npm publish --dry-run
npm notice
npm notice 📦 @metamask/oss-attribution-generator@1.7.1
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 2.7kB README.md
npm notice 8.7kB index.js
npm notice 1.1kB package.json
npm notice === Tarball Details ===
npm notice name: @metamask/oss-attribution-generator
npm notice version: 1.7.1
npm notice filename: @metamask/oss-attribution-generator-1.7.1.tgz
npm notice package size: 4.8 kB
npm notice unpacked size: 13.6 kB
npm notice shasum: e370780bf10834111cabc60f330e143de331ddae
npm notice integrity: sha512-rEP9PnVqm1MI2[...]gUVym6/HHgdPg==
npm notice total files: 4
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ @metamask/oss-attribution-generator@1.7.1
```